### PR TITLE
allowing to filter query by json objects

### DIFF
--- a/parse-livequery/src/main/java/tgio/parselivequery/BaseQuery.java
+++ b/parse-livequery/src/main/java/tgio/parselivequery/BaseQuery.java
@@ -31,7 +31,7 @@ public class BaseQuery {
     public @interface op {}
     public String className;
     public String whereKey;
-    public String whereValue;
+    public Object whereValue;
     public @op String op;
     public int requestId;
     public List<String> fields = null;
@@ -115,6 +115,12 @@ public class BaseQuery {
         }
 
         public Builder where(String key, String value) {
+            this.baseQuery.whereKey = key;
+            this.baseQuery.whereValue = value;
+            return this;
+        }
+
+        public Builder where(String key, JSONObject value) {
             this.baseQuery.whereKey = key;
             this.baseQuery.whereValue = value;
             return this;


### PR DESCRIPTION
We have a live query on a pointer-typed column.

To make it work on Android we added an overloaded version of your `where` method that takes `JSONObject`s so we are very flexible to build our queries.

This is not ideal, because we have to build the `JSONObject` by hand as Parse on Android, different from JavaScript, does not allow to call `toJSON` on a `ParseObject`. Still, it provides enough flexibility to allow people to write all queries they are interested in, not only queries filtering on `String`-typed columns.